### PR TITLE
request->send(200, textPlainStr, jsonChartDataCharStr); - Without using String Class - to save heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ request->send(200, textPlainStr, cStr, false); // this will have to be a cString
 
 in my application max heap size went from 375k to 66k (which is the lowest possible wit the variables and otehr data I am using)
 
-Seems to work, let mw know what you think
+Seems to work, let me know what you think
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@
 ---
 ---
 
+
+*****
+Added a destructive C string interface to send
+
+if called with 
+request->send(200, textPlainStr, ArduinoStr);  // no difference
+request->send(200, textPlainStr, cStr);        // no differfence
+request->send(200, textPlainStr, cStr, false); // this will have to be a cString with enough space to fit the header, it will be memmoved as required, header added, and sent, without creating any large arduino Strings that consume heap
+
+in my application max heap size went from 375k to 66k (which is the lowest possible wit the variables and otehr data I am using)
+
+Seems to work, let mw know what you think
+
+
+
 ## Table of contents
 
 * [Table of contents](#table-of-contents)

--- a/src/Portenta_H7_AsyncWebRequest.cpp
+++ b/src/Portenta_H7_AsyncWebRequest.cpp
@@ -1101,6 +1101,13 @@ void AsyncWebServerRequest::send(AsyncWebServerResponse *response)
   }  
 }
 
+//RSMOD///////////////////////////////////////////////
+
+AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(int code, const String& contentType, const char * content)
+{
+  return new AsyncBasicResponse(code, contentType, content);
+}
+
 /////////////////////////////////////////////////
 
 AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(int code, const String& contentType, const String& content)
@@ -1138,6 +1145,17 @@ AsyncResponseStream * AsyncWebServerRequest::beginResponseStream(const String& c
 {
   return new AsyncResponseStream(contentType, bufferSize);
 }
+
+//RSMOD///////////////////////////////////////////////
+
+void AsyncWebServerRequest::send(int code, const String& contentType, const char *content, bool nonDetructiveSend)
+{
+  if (nonDetructiveSend == true) {
+	send(beginResponse(code, contentType, String(content)));	// for backwards compatibility
+  } else {
+	send(beginResponse(code, contentType, content));
+  }
+ }
 
 /////////////////////////////////////////////////
 

--- a/src/Portenta_H7_AsyncWebResponseImpl.h
+++ b/src/Portenta_H7_AsyncWebResponseImpl.h
@@ -43,9 +43,11 @@ class AsyncBasicResponse: public AsyncWebServerResponse
 {
   private:
     String _content;
+	char *_contentCstr;			// RSMOD
     
   public:
     AsyncBasicResponse(int code, const String& contentType = String(), const String& content = String());
+	AsyncBasicResponse(int code, const String& contentType, const char *content);			// RSMOD
     void _respond(AsyncWebServerRequest *request);
     
     size_t _ack(AsyncWebServerRequest *request, size_t len, uint32_t time);

--- a/src/Portenta_H7_AsyncWebServer.h
+++ b/src/Portenta_H7_AsyncWebServer.h
@@ -340,12 +340,14 @@ class AsyncWebServerRequest
 
     void send(AsyncWebServerResponse *response);
     void send(int code, const String& contentType = String(), const String& content = String());
+	void send(int code, const String& contentType, const char *content, bool nonDetructiveSend = true);		// RSMOD
 
     void send(Stream &stream, const String& contentType, size_t len, AwsTemplateProcessor callback = nullptr);
     void send(const String& contentType, size_t len, AwsResponseFiller callback, AwsTemplateProcessor templateCallback = nullptr);
     void sendChunked(const String& contentType, AwsResponseFiller callback, AwsTemplateProcessor templateCallback = nullptr);
 
     AsyncWebServerResponse *beginResponse(int code, const String& contentType = String(), const String& content = String());
+	AsyncWebServerResponse *beginResponse(int code, const String& contentType, const char * content);	// RSMOD
 
     AsyncWebServerResponse *beginResponse(Stream &stream, const String& contentType, size_t len, AwsTemplateProcessor callback = nullptr);
     AsyncWebServerResponse *beginResponse(const String& contentType, size_t len, AwsResponseFiller callback, AwsTemplateProcessor templateCallback = nullptr);


### PR DESCRIPTION
This PR is from @salasidis

---

As per the Readme.md file - I am getting 66k instead of 374k max heap space in my application. I should have no problem sending 2M files, or web pages larger than the main RAM

Since I create the web page once, and reuse, I make a second copy of the web page, so that when the send happens (which messes wit the actual string), I simply recopy C string C string for the next send - fast, easy, and almost no code changes required (none if you don't wish to use the features 0 fully backwards compatible I think)

```cpp
request->send(200, "text/html", html_out, false);
strcpy(html_out, html_out_bak);
```